### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> ⚠️ **This repository is archived.**
+>
+> Tigris has pivoted from this database project to a new, globally distributed S3-compatible object storage service.
+> Learn more about the new product here: https://www.tigrisdata.com/
+
 # RESTful Web App with Java and Tigris
 
 [![java-ci](https://github.com/tigrisdata/tigris-starter-java/actions/workflows/java-ci.yml/badge.svg?branch=main)](https://github.com/tigrisdata/tigris-starter-java/actions/workflows/java-ci.yml)


### PR DESCRIPTION
This PR adds an archive notice to the README to reflect Tigris' pivot to a globally distributed S3-compatible object storage service.